### PR TITLE
add instructions how to use metro instead of weback for expo SDK 51

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Expo's SDK 51 does not support webpack out of the box as in past versions. They 
 So to replace the metro.config.js instructions above, create in the root of your project a metro.config.js file.
 In that place:
 
-```
+```js
 // Learn more https://docs.expo.io/guides/customizing-metro
 const { getDefaultConfig } = require('expo/metro-config');
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ module.exports = async function (env, argv) {
   return config;
 };
 ```
-### Update for Expo SDK 51: SDK 51 use metro
+### Update for Expo SDK 51: use metro instead of webpack
 Expo's SDK 51 does not support webpack out of the box as in past versions. They suggest using metro instead.
 
 So to replace the metro.config.js instructions above, create in the root of your project a metro.config.js file.

--- a/README.md
+++ b/README.md
@@ -66,3 +66,43 @@ module.exports = async function (env, argv) {
   return config;
 };
 ```
+### Update for Expo SDK 51: SDK 51 use metro
+Expo's SDK 51 does not support webpack out of the box as in past versions. They suggest using metro instead.
+
+So to replace the metro.config.js instructions above, create in the root of your project a metro.config.js file.
+In that place:
+
+```
+// Learn more https://docs.expo.io/guides/customizing-metro
+const { getDefaultConfig } = require('expo/metro-config');
+
+/** @type {import('expo/metro-config').MetroConfig} */
+const config = getDefaultConfig(__dirname);
+
+const ALIASES = {
+    'react-native': 'react-native-web',
+    'react-native-webview': '@10play/react-native-web-webview'
+};
+
+/**
+ * This maps moduleName: string -> newmoduleName: string given co
+ * @param {T} context 
+ * @param {string} moduleName 
+ * @param {string} platform   in {"web", ... }
+ * @returns 
+ */
+config.resolver.resolveRequest = (context, moduleName, platform) => {
+    // Ensure you call the default resolver.
+    if (platform === 'web') {
+        return context.resolveRequest(
+            context,
+            // Use an alias if one exists.
+            ALIASES[moduleName] ?? moduleName,
+            platform
+        );
+    } 
+    return context.resolveRequest(context, moduleName, platform);
+
+};
+module.exports = config;
+```


### PR DESCRIPTION
How to use react-native-web-webview with expo SDK 51 which suggests using metro instead of webpack for creating webapps